### PR TITLE
We want to use any available version of a JSON parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,6 @@ group :development do
 end
 
 gem "oauth2",     "~> 0.8"
-gem "yajl-ruby",  "~> 1.1"
+gem "multi_json",  "~> 1.7"
 gem "hashie",     "~> 1.2"
 gem "mime-types", "~> 1.19"

--- a/lib/skittles.rb
+++ b/lib/skittles.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'yajl'
+require 'multi_json'
 require 'hashie'
 require File.expand_path('../skittles/utils', __FILE__)
 require File.expand_path('../skittles/error', __FILE__)

--- a/lib/skittles.rb
+++ b/lib/skittles.rb
@@ -1,3 +1,6 @@
+require 'uri'
+require 'yajl'
+require 'hashie'
 require File.expand_path('../skittles/utils', __FILE__)
 require File.expand_path('../skittles/error', __FILE__)
 require File.expand_path('../skittles/version', __FILE__)

--- a/lib/skittles/request.rb
+++ b/lib/skittles/request.rb
@@ -1,7 +1,3 @@
-require 'uri'
-require 'yajl'
-require 'hashie'
-
 module Skittles
   module Request
     # Perform an HTTP GET request

--- a/lib/skittles/utils.rb
+++ b/lib/skittles/utils.rb
@@ -23,7 +23,7 @@ module Skittles
       
       # Parses JSON and returns a Hashie::Mash
       def self.parse_json(json)
-        Hashie::Mash.new(Yajl::Parser.new.parse(json))
+        Hashie::Mash.new(MultiJson.load(json))
       end
 
       def deprecated(deprecated_method, replacement_method)


### PR DESCRIPTION
This change will allow anyone using skittles to have their own JSON parser and open up skittles to the other interpretors. Those that are using Oj will get a performance improvement.
